### PR TITLE
fix unerasable-optional-argument by making `sep` argument required

### DIFF
--- a/lib/blog.ml
+++ b/lib/blog.ml
@@ -96,12 +96,16 @@ end
 (** Entries separated by <hr /> tags *)
 let default_separator = Html.hr
 
-(** [to_html ?sep feed entries] renders a series of entries in a feed, separated
-    by [sep], defaulting to [default_separator]. *)
-let to_html ?(sep=default_separator) ~feed ~entries =
+(** [to_html sep feed entries] renders a series of entries in a feed, separated
+    by [sep] when [Some sep] is passed, defaulting to [default_separator] for [None]. *)
+let to_html ~sep ~feed ~entries =
   let rec concat = function
     | [] -> Lwt.return Html.empty
     | hd::tl ->
+      let sep = match sep with
+      | Some s -> s
+      | None -> default_separator
+      in
       Entry.to_html ~feed ~entry:hd >>= fun hd ->
       concat tl >|= fun tl ->
       Html.list [ hd; sep; tl ]

--- a/lib/blog.mli
+++ b/lib/blog.mli
@@ -31,7 +31,7 @@ module Entry : sig
 end
 
 val to_html :
-  ?sep:Cow.Xml.t ->
+  sep:Cow.Xml.t option ->
   feed:Atom_feed.t ->
   entries:Entry.t list ->
   Cow.Xml.t Lwt.t


### PR DESCRIPTION
This fixes cowabloga builds on OCaml 4.12.0. The semantics are compatible with mirage-www's use of the function.